### PR TITLE
fix: leave connection & channel open

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@goparrot/pubsub-event-bus",
     "description": "NestJS EventBus extension for RabbitMQ PubSub",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "main": "src/index.js",
     "scripts": {
         "commit": "git-cz",

--- a/src/interface/PubsubEvent.ts
+++ b/src/interface/PubsubEvent.ts
@@ -3,6 +3,7 @@ import { PublishOptions } from './PublishOptions';
 export abstract class PubsubEvent<T extends Record<string, any> | Buffer> {
     // Default publish options.
     protected options: PublishOptions = {};
+    protected fireLocally: boolean = true;
 
     constructor(protected data: T) {}
 
@@ -15,9 +16,18 @@ export abstract class PubsubEvent<T extends Record<string, any> | Buffer> {
     // Get publish options.
     getOptions = (): PublishOptions => this.options;
 
+    // Get local publishing option.
+    localEventEnabled = (): boolean => this.fireLocally;
+
     // Set the publish options at runtime (overrides the default publish options).
     withOptions = (extra: PublishOptions): PubsubEvent<T> => {
         this.options = { ...this.options, ...extra };
+
+        return this;
+    };
+
+    withLocalEvent = (allow: boolean = true): PubsubEvent<T> => {
+        this.fireLocally = allow;
 
         return this;
     };

--- a/src/service/Publisher.ts
+++ b/src/service/Publisher.ts
@@ -11,10 +11,11 @@ export class Publisher<EventBase extends IEvent> extends DefaultPubSub<EventBase
     }
 
     async publish<T extends EventBase>(event: T): Promise<void> {
-        super.publish(event);
-
         if (event instanceof PubsubEvent) {
-            await this.producer.produce(toEventName(event.constructor.name), event.payload(), event.exchange(), event.getOptions());
+            event.localEventEnabled() && super.publish(event);
+            return this.producer.produce(toEventName(event.constructor.name), event.payload(), event.exchange(), event.getOptions());
         }
+
+        return super.publish(event);
     }
 }

--- a/src/service/PubsubManager.ts
+++ b/src/service/PubsubManager.ts
@@ -1,43 +1,58 @@
 import * as RabbitManager from 'amqp-connection-manager';
 import { AmqpConnectionManager, ChannelWrapper } from 'amqp-connection-manager';
-import { ConfirmChannel } from 'amqplib';
-import { LoggerService, OnModuleDestroy } from '@nestjs/common';
+import { ConfirmChannel, Connection } from 'amqplib';
+import { LoggerService, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { ConfigProvider, ConnectionProvider, LoggerProvider } from '../provider';
 import { ExchangeOptions } from '../interface';
 
-export abstract class PubsubManager implements OnModuleDestroy {
-    protected connection: AmqpConnectionManager;
+/**
+ * Review the work with connections & channels, according to these recommendations.
+ * https://www.cloudamqp.com/blog/2018-01-19-part4-rabbitmq-13-common-errors.html
+ */
+export abstract class PubsubManager implements OnModuleInit, OnModuleDestroy {
+    protected connection$: AmqpConnectionManager;
+    protected channelWrapper$: ChannelWrapper;
 
-    async onModuleDestroy(): Promise<any> {
-        this.connection && (await this.connection.close());
+    async onModuleInit(): Promise<void> {
+        if (this.appInTestingMode()) return;
+
+        this.connection$ = RabbitManager.connect(ConnectionProvider.connections, {
+            heartbeatIntervalInSeconds: 5,
+            reconnectTimeInSeconds: 5,
+        })
+            .on('connect', ({ url }: { connection: Connection; url: string }) => void this.logger().log(`Amqp connection established`, url))
+            .on('disconnect', (arg: { err: Error }) => void this.logger().error(arg.err.message));
+
+        this.channelWrapper$ = this.connection$
+            .createChannel({ json: true })
+            .on('connect', () => void this.logger().log(`Amqp channel created`))
+            .on('error', (err: Error, { name }: { name: string }) => void this.logger().error(`Amqp channel error: ${err.message}`, err.stack, name))
+            .on('close', () => void this.logger().log(`Amqp channel closes`));
+    }
+
+    async onModuleDestroy(): Promise<void> {
+        this.channelWrapper$ && (await this.channelWrapper$.close());
+        this.connection$ && (await this.connection$.close());
     }
 
     protected logger(): LoggerService {
         return LoggerProvider.logger;
     }
 
-    protected async channel(exchange: string, onExchangeCreated?: (channel: ConfirmChannel) => any): Promise<ChannelWrapper> {
-        if (!this.connection?.isConnected()) {
-            this.connection = RabbitManager.connect(ConnectionProvider.connections, {
-                heartbeatIntervalInSeconds: 5,
-                reconnectTimeInSeconds: 5,
-            });
+    protected async channel(exchange: string, onExchangeCreated?: (channel: ConfirmChannel) => unknown): Promise<void> {
+        void this.connection$
+            .createChannel({
+                json: true,
+                setup: async (channel: ConfirmChannel): Promise<any> =>
+                    Promise.all([
+                        channel.assertExchange(exchange, 'topic', this.exchangeOptions()),
+                        ...(onExchangeCreated ? [onExchangeCreated(channel)] : []),
+                    ]),
+            })
+            .waitForConnect()
+            .then((): void => void this.logger().log(`Listening for "${exchange}" messages`));
 
-            this.connection.on('disconnect', (arg: { err: Error }) => {
-                // Connection handler uses auto-retries mechanism.
-                // So far, this is the only way to ensure, the connection was established.
-                this.logger().error(arg.err.message);
-            });
-        }
-
-        return this.connection.createChannel({
-            json: true,
-            setup: async (channel: ConfirmChannel): Promise<any> => {
-                await channel.assertExchange(exchange, 'topic', this.exchangeOptions());
-
-                onExchangeCreated && onExchangeCreated(channel);
-            },
-        });
+        return;
     }
 
     protected exchangeOptions(extra: ExchangeOptions = {}): ExchangeOptions {
@@ -46,4 +61,6 @@ export abstract class PubsubManager implements OnModuleDestroy {
             ...extra,
         };
     }
+
+    private appInTestingMode = (): boolean => 'test' === process.env.NODE_ENV!;
 }


### PR DESCRIPTION
* establish & close connections/channels on the module init/destroy
* share the same connection between processes
* fix the issue with closing connection for multiple consequent publishers
* add the ability to disable the local event propagation (no local event will be published, but RabbitMQ)
* improve performance, by batching the channel setup step