### PR TITLE
fix(logger): remove connection string from logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@goparrot/pubsub-event-bus",
     "description": "NestJS EventBus extension for RabbitMQ PubSub",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "main": "src/index.js",
     "scripts": {
         "commit": "git-cz",

--- a/src/service/PubsubManager.ts
+++ b/src/service/PubsubManager.ts
@@ -1,6 +1,6 @@
 import * as RabbitManager from 'amqp-connection-manager';
 import { AmqpConnectionManager, ChannelWrapper } from 'amqp-connection-manager';
-import { ConfirmChannel, Connection } from 'amqplib';
+import { ConfirmChannel } from 'amqplib';
 import { LoggerService, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { ConfigProvider, ConnectionProvider, LoggerProvider } from '../provider';
 import { ExchangeOptions } from '../interface';
@@ -20,7 +20,7 @@ export abstract class PubsubManager implements OnModuleInit, OnModuleDestroy {
             heartbeatIntervalInSeconds: 5,
             reconnectTimeInSeconds: 5,
         })
-            .on('connect', ({ url }: { connection: Connection; url: string }) => void this.logger().log(`Amqp connection established`, url))
+            .on('connect', () => void this.logger().log(`Amqp connection established`))
             .on('disconnect', (arg: { err: Error }) => void this.logger().error(arg.err.message));
 
         this.channelWrapper$ = this.connection$


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://github.com/goparrot/geocoder/blob/master/CONTRIBUTING.md#contributing
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->

<!-- This is a 🙋 feature or enhancement. -->

<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `npm test` to verify this)
-->

## Summary

Remove the connection string from logs

## Context

The connection strings are exposed once the connection is established.
