### PR TITLE
feat: allow to map an Event class to a custom event name

### DIFF
--- a/bin/npm-dev-version.ts
+++ b/bin/npm-dev-version.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
+import { EOL } from 'os';
 import parseArgs from 'minimist';
 import { SemVer } from 'semver';
 
@@ -40,5 +41,5 @@ void (async (): Promise<void> => {
     console.log('Output data', { packageJsonPath, branchName, ticketNumber, version: semVer.format() });
 
     packageJson.version = semVer.format();
-    writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 4));
+    writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 4) + EOL);
 })();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@goparrot/pubsub-event-bus",
     "description": "NestJS EventBus extension for RabbitMQ PubSub",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "main": "src/index.js",
     "scripts": {
         "commit": "git-cz",

--- a/src/CqrsModule.ts
+++ b/src/CqrsModule.ts
@@ -1,11 +1,11 @@
-import type { DynamicModule, OnApplicationBootstrap } from '@nestjs/common';
 import { Logger, Module } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { CqrsModule as NestCqrsModule } from '@nestjs/cqrs';
-import type { ICqrsModuleOptions } from './interface';
 import { ConfigProvider, ConnectionProvider, LoggerProvider } from './provider';
 import { CommandBus, Consumer, EventBus, ExplorerService, Producer, Publisher, QueryBus } from './service';
 import { CONSUMER_OPTIONS, DEFAULT_CONSUMER_OPTIONS } from './utils/configuration';
+import type { ICqrsModuleOptions } from './interface';
+import type { DynamicModule, OnApplicationBootstrap } from '@nestjs/common';
 
 @Module({
     imports: [NestCqrsModule],

--- a/src/decorator/PubsubEventHandler.ts
+++ b/src/decorator/PubsubEventHandler.ts
@@ -1,7 +1,7 @@
+import { PUBSUB_EVENT_HANDLER_METADATA } from './constant';
 import type { Type } from '@nestjs/common';
 import 'reflect-metadata';
 import type { AutoAckEnum, PubsubEvent } from '../interface';
-import { PUBSUB_EVENT_HANDLER_METADATA } from './constant';
 
 export interface IPubsubEventHandlerOptions {
     /**

--- a/src/decorator/PubsubEventName.ts
+++ b/src/decorator/PubsubEventName.ts
@@ -1,0 +1,8 @@
+import { PUBSUB_EVENT_NAME } from './constant';
+
+export function PubsubEventName(name: string): ClassDecorator {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    return (target: object): void => {
+        Reflect.defineMetadata(PUBSUB_EVENT_NAME, name, target);
+    };
+}

--- a/src/decorator/constant.ts
+++ b/src/decorator/constant.ts
@@ -1,1 +1,2 @@
 export const PUBSUB_EVENT_HANDLER_METADATA = '__pubsubEventsHandler';
+export const PUBSUB_EVENT_NAME = '__pubsubEventName';

--- a/src/decorator/index.ts
+++ b/src/decorator/index.ts
@@ -1,2 +1,3 @@
 export * from './constant';
+export * from './PubsubEventName';
 export * from './PubsubEventHandler';

--- a/src/provider/ConfigProvider.ts
+++ b/src/provider/ConfigProvider.ts
@@ -1,10 +1,10 @@
-import type { BindingQueueOptions, ExchangeOptions, ICqrsModuleOptions, PublishOptions, PubsubExchangeType } from '../interface';
 import {
     DEFAULT_EXCHANGE_CONFIGURATION,
     DEFAULT_EXCHANGE_TYPE,
     DEFAULT_PRODUCER_CONFIGURATION,
     DEFAULT_QUEUE_BINDING_CONFIGURATION,
 } from '../utils/configuration';
+import type { BindingQueueOptions, ExchangeOptions, ICqrsModuleOptions, PublishOptions, PubsubExchangeType } from '../interface';
 
 export class ConfigProvider {
     static exchange: ExchangeOptions;

--- a/src/service/Consumer.ts
+++ b/src/service/Consumer.ts
@@ -1,14 +1,14 @@
-import type { LoggerService, Type } from '@nestjs/common';
 import { Inject } from '@nestjs/common';
-import type { IEventHandler } from '@nestjs/cqrs';
-import type { ChannelWrapper } from 'amqp-connection-manager';
-import type { ConfirmChannel, ConsumeMessage, Message } from 'amqplib';
-import type { BindingQueueOptions, PubsubEvent } from '../interface';
 import { AutoAckEnum, IConsumerOptions, PubsubHandler } from '../interface';
 import { ConfigProvider } from '../provider';
 import { toEventName, toSnakeCase } from '../utils';
 import { CONSUMER_OPTIONS } from '../utils/configuration';
 import { PubsubManager } from './PubsubManager';
+import type { BindingQueueOptions, PubsubEvent } from '../interface';
+import type { ConfirmChannel, ConsumeMessage, Message } from 'amqplib';
+import type { ChannelWrapper } from 'amqp-connection-manager';
+import type { IEventHandler } from '@nestjs/cqrs';
+import type { LoggerService, Type } from '@nestjs/common';
 
 export class Consumer extends PubsubManager {
     protected name: string;

--- a/src/service/ExplorerService.ts
+++ b/src/service/ExplorerService.ts
@@ -1,9 +1,9 @@
-import type { Type } from '@nestjs/common';
 import { Injectable } from '@nestjs/common';
 import { ExplorerService as NestExplorerService } from '@nestjs/cqrs/dist/services/explorer.service';
 import { ModulesContainer } from '@nestjs/core';
-import type { IEvent, IEventHandler } from '@nestjs/cqrs';
 import { PUBSUB_EVENT_HANDLER_METADATA } from '../decorator';
+import type { IEvent, IEventHandler } from '@nestjs/cqrs';
+import type { Type } from '@nestjs/common';
 
 @Injectable()
 export class ExplorerService extends NestExplorerService {

--- a/src/service/Producer.ts
+++ b/src/service/Producer.ts
@@ -1,6 +1,6 @@
-import type { PublishOptions } from '../interface';
 import { ConfigProvider } from '../provider';
 import { PubsubManager } from './PubsubManager';
+import type { PublishOptions } from '../interface';
 
 export class Producer extends PubsubManager {
     /**

--- a/src/service/Publisher.ts
+++ b/src/service/Publisher.ts
@@ -1,8 +1,8 @@
-import type { IEvent } from '@nestjs/cqrs';
 import { DefaultPubSub } from '@nestjs/cqrs/dist/helpers/default-pubsub';
-import type { Subject } from 'rxjs';
 import { toEventName } from '../utils';
 import { PubsubEvent } from '../interface';
+import type { Subject } from 'rxjs';
+import type { IEvent } from '@nestjs/cqrs';
 import type { Producer } from './Producer';
 
 export class Publisher<EventBase extends IEvent> extends DefaultPubSub<EventBase> {

--- a/src/service/PubsubManager.ts
+++ b/src/service/PubsubManager.ts
@@ -1,9 +1,9 @@
+import * as RabbitManager from 'amqp-connection-manager';
+import { ConfigProvider, ConnectionProvider, LoggerProvider } from '../provider';
 import type { LoggerService, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import type { AmqpConnectionManager, ChannelWrapper } from 'amqp-connection-manager';
-import * as RabbitManager from 'amqp-connection-manager';
 import type { ConfirmChannel } from 'amqplib';
 import type { ExchangeOptions } from '../interface';
-import { ConfigProvider, ConnectionProvider, LoggerProvider } from '../provider';
 
 /**
  * Review the work with connections & channels, according to these recommendations.


### PR DESCRIPTION
Allows specifying the original event name for custom class name.

A good example of this case can be the following: 

square sends the event: `gift_card.updated`, by naming convention that event would match the event class Gift_CardUpdated...

In order to fix this, event class SquareGiftCardUpdated may be decorated by `@PubsbuEventName('gift_card.updated')` decorator which solves this limitation.