### PR TITLE
Do not open consumer amqp connection when no pub-sub handlers discovered

### DIFF
--- a/src/CqrsModule.ts
+++ b/src/CqrsModule.ts
@@ -1,7 +1,7 @@
 import type { DynamicModule, OnApplicationBootstrap } from '@nestjs/common';
 import { Logger, Module } from '@nestjs/common';
 import { CqrsModule as NestCqrsModule } from '@nestjs/cqrs';
-import type { ICqrsModuleAsyncOptions, ICqrsModuleOptions } from './interface';
+import type { IConsumerOptions, ICqrsModuleAsyncOptions, ICqrsModuleOptions } from './interface';
 import { ConfigProvider, ConnectionProvider, LoggerProvider } from './provider';
 import { CommandBus, Consumer, EventBus, ExplorerService, Producer, PubSubReflector, QueryBus } from './service';
 import { CQRS_MODULE_CONSUMER_OPTIONS, CQRS_MODULE_OPTIONS, DEFAULT_CONSUMER_OPTIONS } from './utils/configuration';
@@ -18,22 +18,30 @@ import { CQRS_MODULE_CONSUMER_OPTIONS, CQRS_MODULE_OPTIONS, DEFAULT_CONSUMER_OPT
         PubSubReflector,
         {
             provide: ConnectionProvider,
-            useFactory: (options: ICqrsModuleOptions): ConnectionProvider => ConnectionProvider.forHosts(options.connections),
+            useFactory(options: ICqrsModuleOptions): ConnectionProvider {
+                return ConnectionProvider.forHosts(options.connections);
+            },
             inject: [CQRS_MODULE_OPTIONS],
         },
         {
             provide: LoggerProvider,
-            useFactory: (options: ICqrsModuleOptions): LoggerProvider => LoggerProvider.forLogger(options.logger || new Logger()),
+            useFactory(options: ICqrsModuleOptions): LoggerProvider {
+                return LoggerProvider.forLogger(options.logger || new Logger());
+            },
             inject: [CQRS_MODULE_OPTIONS],
         },
         {
             provide: ConfigProvider,
-            useFactory: (options: ICqrsModuleOptions): ConfigProvider => ConfigProvider.fromOptions(options),
+            useFactory(options: ICqrsModuleOptions): ConfigProvider {
+                return ConfigProvider.fromOptions(options);
+            },
             inject: [CQRS_MODULE_OPTIONS],
         },
         {
             provide: CQRS_MODULE_CONSUMER_OPTIONS,
-            useFactory: (options: ICqrsModuleOptions): unknown => ({ ...DEFAULT_CONSUMER_OPTIONS, ...options.config?.consumer }),
+            useFactory(options: ICqrsModuleOptions): IConsumerOptions {
+                return { ...DEFAULT_CONSUMER_OPTIONS, ...options.config?.consumer };
+            },
             inject: [CQRS_MODULE_OPTIONS],
         },
     ],

--- a/src/interface/AbstractPubsubAnyEventHandler.ts
+++ b/src/interface/AbstractPubsubAnyEventHandler.ts
@@ -1,0 +1,4 @@
+import type { AbstractPubsubHandler } from './AbstractPubsubHandler';
+import type { AbstractSubscriptionEvent } from './AbstractSubscriptionEvent';
+
+export type AbstractPubsubAnyEventHandler = AbstractPubsubHandler<AbstractSubscriptionEvent<Record<string, any> | Buffer>>;

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -12,3 +12,4 @@ export * from './AbstractPubsubHandler';
 export * from './ICqrsModuleAsyncOptions';
 export * from './AbstractSubscriptionEvent';
 export * from './IPubsubEventHandlerMetadata';
+export * from './AbstractPubsubAnyEventHandler';

--- a/src/service/ExplorerService.ts
+++ b/src/service/ExplorerService.ts
@@ -4,7 +4,7 @@ import { ModulesContainer } from '@nestjs/core';
 import type { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { ExplorerService as NestExplorerService } from '@nestjs/cqrs/dist/services/explorer.service';
 import { PUBSUB_EVENT_HANDLER_METADATA } from '../decorator';
-import type { AbstractPubsubHandler } from '../interface';
+import type { AbstractPubsubAnyEventHandler } from '../interface';
 
 @Injectable()
 export class ExplorerService extends NestExplorerService {
@@ -12,8 +12,8 @@ export class ExplorerService extends NestExplorerService {
         super(modules);
     }
 
-    pubsubEvents(): Type<AbstractPubsubHandler<any>>[] {
-        return this.flatMap<AbstractPubsubHandler<any>>([...this.modules.values()], (instance: InstanceWrapper) => {
+    pubsubEvents(): Type<AbstractPubsubAnyEventHandler>[] {
+        return this.flatMap<AbstractPubsubAnyEventHandler>([...this.modules.values()], (instance: InstanceWrapper) => {
             return this.filterProvider(instance, PUBSUB_EVENT_HANDLER_METADATA);
         });
     }

--- a/src/service/PubsubManager.ts
+++ b/src/service/PubsubManager.ts
@@ -1,4 +1,4 @@
-import type { LoggerService, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import type { LoggerService, OnModuleDestroy } from '@nestjs/common';
 import type { AmqpConnectionManager, ChannelWrapper } from 'amqp-connection-manager';
 import * as RabbitManager from 'amqp-connection-manager';
 import type { ConfirmChannel } from 'amqplib';
@@ -9,39 +9,57 @@ import { ConfigProvider, ConnectionProvider, LoggerProvider } from '../provider'
  * Review the work with connections & channels, according to these recommendations.
  * https://www.cloudamqp.com/blog/2018-01-19-part4-rabbitmq-13-common-errors.html
  */
-export abstract class PubsubManager implements OnModuleInit, OnModuleDestroy {
+export abstract class PubsubManager implements OnModuleDestroy {
     private connection$: AmqpConnectionManager | undefined;
+
+    protected get connection(): AmqpConnectionManager {
+        if (!this.connection$) {
+            throw new Error('Amqp connection has not been initialized');
+        }
+        return this.connection$;
+    }
+
     private channelWrapper$: ChannelWrapper | undefined;
 
     protected get channelWrapper(): ChannelWrapper {
         if (!this.channelWrapper$) {
-            throw new Error('Amqp connection has not been initialized');
+            throw new Error('Amqp channel has not been initialized');
         }
         return this.channelWrapper$;
     }
 
     async setupChannel(_channel: ConfirmChannel): Promise<void> {}
 
-    async onModuleInit(): Promise<void> {
-        if (this.appInTestingMode()) return;
+    protected initConnectionIfRequired(): void {
+        if (this.connection$) {
+            return;
+        }
 
         this.connection$ = RabbitManager.connect(ConnectionProvider.connections, {
             heartbeatIntervalInSeconds: 5,
             reconnectTimeInSeconds: 5,
         })
-            .on('connect', () => void this.logger().log(`Amqp connection established`))
-            .on('disconnect', (arg: { err: Error }) => void this.logger().error(arg.err.message));
+            .on('connect', () => this.logger().log('Amqp connection established', this.constructor.name))
+            .on('disconnect', (arg: { err: Error }) => this.logger().error(arg.err.message, undefined, this.constructor.name));
+    }
 
-        this.channelWrapper$ = this.connection$
+    protected initChannelIfRequired(): void {
+        if (this.channelWrapper$) {
+            return;
+        }
+
+        this.channelWrapper$ = this.connection
             .createChannel({ json: true, setup: this.setupChannel.bind(this) })
-            .on('connect', () => void this.logger().log(`Amqp channel created`))
-            .on('error', (err: Error, { name }: { name: string }) => void this.logger().error(`Amqp channel error: ${err.message}`, err.stack, name))
-            .on('close', () => void this.logger().log(`Amqp channel closes`));
+            .on('connect', () => this.logger().log(`Amqp channel created`, this.constructor.name))
+            .on('error', (err: Error, { name }: { name?: string }) =>
+                this.logger().error(`Amqp channel error: ${err.message}`, err.stack, name ?? this.constructor.name),
+            )
+            .on('close', () => this.logger().log(`Amqp channel closed`, this.constructor.name));
     }
 
     async onModuleDestroy(): Promise<void> {
-        this.channelWrapper$ && (await this.channelWrapper$.close());
-        this.connection$ && (await this.connection$.close());
+        await this.channelWrapper$?.close();
+        await this.connection$?.close();
     }
 
     protected logger(): LoggerService {


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://github.com/goparrot/nestjs-pubsub-event-bus/blob/master/CONTRIBUTING.md#contributing
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->

This is a 🙋 feature or enhancement.

<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `npm test` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Move AMQP connection and channel initialization from abstract `PubSubManager` to its implementations `Producer` and `Consumer`. `Producer` initializes them on the app bootstrap. `Consumer` initializes them on the first requirement.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

This enhancement allows avoiding consumer connection initialization when there are no pub-sub handlers

Resolves #17 