### PR TITLE
fix: correct default retry delay to exp seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,10 @@ ones.
 
 Available options:
 
-| Options          | Description                                                                                                                                            | Module-level default value | Handler-level default value |
-|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|-----------------------------|
-| maxRetryAttempts | Maximum number of retry attempts                                                                                                                       | 3                          |                             |
-| delay            | Delay between retry attempts in milliseconds. Can be a fixed positive number or a function that receives current retry attempt count and returns delay | `Math.exp`                 |                             |
+| Options          | Description                                                                                                                                            | Module-level default value    | Handler-level default value |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-----------------------------|
+| maxRetryAttempts | Maximum number of retry attempts                                                                                                                       | 3                             |                             |
+| delay            | Delay between retry attempts in milliseconds. Can be a fixed positive number or a function that receives current retry attempt count and returns delay | `1000 * Math.exp(retryCount)` |                             |
 
 When number of retry attempts is exceeded handler method `onRetryAttemptsExceeded` is called with the event and last
 error as arguments. Then message is discarded.

--- a/src/interface/IRetryOptions.ts
+++ b/src/interface/IRetryOptions.ts
@@ -7,7 +7,7 @@ export interface IRetryOptions {
 
     /**
      * Delay before each attempt. A fixed value or a function
-     * @default Math.exp
+     * @default 1000 * Math.exp(retryCount)
      */
     delay?: number | ((retryCount: number) => number);
 }

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -35,7 +35,7 @@ export const DEFAULT_CONSUMER_OPTIONS: IConsumerOptions = {
 
 export const DEFAULT_RETRY_OPTIONS: IRetryOptions = {
     maxRetryAttempts: 3,
-    delay: Math.exp,
+    delay: (retryCount: number) => 1000 * Math.exp(retryCount),
 };
 
 export const DEFAULT_CONNECTION_MANAGER_OPTIONS: AmqpConnectionManagerOptions = {};


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://github.com/goparrot/nestjs-pubsub-event-bus/blob/master/CONTRIBUTING.md#contributing
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.

<!-- This is a 🙋 feature or enhancement. -->

<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `npm test` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Correct default retry delay to exp seconds instead of milliseconds

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
