### PR TITLE
fix: use last split package name part as queue name prefix

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,7 @@
 import snakeCase from 'lodash/snakeCase';
 import startCase from 'lodash/startCase';
 import type { Message } from 'amqplib';
+import last from 'lodash/last';
 import type { DelayType } from '../interface';
 import { ORIGIN_EXCHANGE_HEADER } from './retry-constants';
 
@@ -43,7 +44,7 @@ export function calculateDelay(delay: DelayType, retryCount: number): number {
 }
 
 export function generateQueuePrefixFromPackageName(): string | undefined {
-    return process.env.npm_package_name?.split('/')[0].replace(/[_-]/gi, '.');
+    return last(process.env.npm_package_name?.split('/'))?.replace(/[_-]/gi, '.');
 }
 
 export function getMessageExchange(message: Message): string {

--- a/test/unit/utils/helpers.test.ts
+++ b/test/unit/utils/helpers.test.ts
@@ -1,4 +1,4 @@
-import { toEventClassName, toEventName, toSnakeCase } from '../../../src';
+import { generateQueuePrefixFromPackageName, toEventClassName, toEventName, toSnakeCase } from '../../../src';
 
 describe('Utils', () => {
     describe('toEventName', () => {
@@ -28,6 +28,20 @@ describe('Utils', () => {
 
         it('should disregard the Handler word', function () {
             expect(toSnakeCase('NotifyUserHandler')).toBe('notify_user');
+        });
+    });
+
+    describe('generateQueuePrefixFromPackageName', () => {
+        it.each`
+            packageName                          | expected
+            ${'@goparrot/platform-some-service'} | ${'platform.some.service'}
+            ${'@goparrot/platform-some'}         | ${'platform.some'}
+            ${'@goparrot/some-service'}          | ${'some.service'}
+            ${'some-service'}                    | ${'some.service'}
+        `('should generate queue prefix from %packageName', ({ packageName, expected }) => {
+            process.env.npm_package_name = packageName;
+
+            expect(generateQueuePrefixFromPackageName()).toBe(expected);
         });
     });
 });


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://github.com/goparrot/nestjs-pubsub-event-bus/blob/master/CONTRIBUTING.md#contributing
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.

<!-- This is a 🙋 feature or enhancement. -->

<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `npm test` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Use last split package name part as queue name prefix (was broken in #36)

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
