### PR TITLE
feat(nack): add requeue option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@goparrot/pubsub-event-bus",
     "description": "NestJS EventBus extension for RabbitMQ PubSub",
-    "version": "5.0.0-dev.vb.1",
+    "version": "5.0.0-dev.vb.3",
     "author": "GoParrot",
     "keywords": [
         "NestJS",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@goparrot/pubsub-event-bus",
     "description": "NestJS EventBus extension for RabbitMQ PubSub",
-    "version": "5.0.0",
+    "version": "5.0.0-dev.vb.1",
     "author": "GoParrot",
     "keywords": [
         "NestJS",

--- a/src/interface/AbstractPubsubHandler.ts
+++ b/src/interface/AbstractPubsubHandler.ts
@@ -18,5 +18,5 @@ export abstract class AbstractPubsubHandler<T extends AbstractSubscriptionEvent<
      * This method should be used only when automatic acknowledge is disabled.
      * This method should not be overridden
      */
-    nack(_event: AbstractSubscriptionEvent<any>): void {}
+    nack(_event: AbstractSubscriptionEvent<any>, _requeue?: boolean): void {}
 }

--- a/src/interface/IChannelWrapper.ts
+++ b/src/interface/IChannelWrapper.ts
@@ -4,7 +4,7 @@ import type { PublishOptions } from './PublishOptions';
 export interface IChannelWrapper {
     ack(message: Message): void;
 
-    nack(message: Message): void;
+    nack(message: Message, requeue?: boolean): void;
 
     publish(exchange: string, routingKey: string, content: Buffer | string | unknown, options?: PublishOptions): Promise<void>;
 }

--- a/src/service/Consumer.ts
+++ b/src/service/Consumer.ts
@@ -129,11 +129,11 @@ export class Consumer extends PubsubManager implements IChannelWrapper {
         this.channelWrapper.ack(message);
     }
 
-    nack(message: Message): void {
+    nack(message: Message, requeue?: boolean): void {
         if (appInTestingMode()) {
             return;
         }
-        this.channelWrapper.nack(message);
+        this.channelWrapper.nack(message, false, requeue);
     }
 
     async publish(exchange: string, routingKey: string, content: Buffer | string | unknown, options?: PublishOptions): Promise<void> {


### PR DESCRIPTION
This is a 🙋 feature or enhancement.
## Summary
In order to have ability to flag that message should be re-queued